### PR TITLE
Adds missing core-style dependency to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "polymer": "Polymer/polymer#master",
     "core-selector": "Polymer/core-selector#master",
+    "core-style": "Polymer/core-style#master",
     "core-transition": "Polymer/core-transition#master"
   }
 }


### PR DESCRIPTION
I went to install some specific Polymer dependencies and caught this.

Used in [transitions/core-transition-pages.html#L11](/Polymer/core-animated-pages/blob/7f503c1f779878de1c903e9291cf6c7331a06b62/transitions/core-transition-pages.html#L11)
