### PR TITLE
Fixed bug where a blank card is displayed

### DIFF
--- a/demos/music.html
+++ b/demos/music.html
@@ -154,11 +154,9 @@
       selectedAlbum: null,
 
       transition: function(e) {
-        if (this.page === 0) {
+        if (this.page === 0 && e.target.templateInstance.model.item) {
           this.selectedAlbum = e.target.templateInstance.model.item;
-          if(this.selectedAlbum != null) {
-            this.page = 1;
-          }
+          this.page = 1;
         } else {
           this.page = 0;
         }


### PR DESCRIPTION
on-tap is attached to both the chip-container and the card.
To know which card gets displayed, the transition function called
by on-tap assigns the selectedAlbum variable the value of the target's
templateInstance.model.item, which is null if the user clicks on any
area which is inside chip-container, but outside a chip. This results
to a blank card being displayed:

![screenshot from 2014-07-16 22 38 47](https://cloud.githubusercontent.com/assets/2637890/3600900/65ce799a-0cfc-11e4-8037-4d1d76654e05.png)

The simplest fix for this is to check if selectedAlbum is null before
setting the page flag to 1.
