### PR TITLE
Update readme to mention tile-cascade is not included

### DIFF
--- a/core-animated-pages.html
+++ b/core-animated-pages.html
@@ -19,8 +19,8 @@
 when switching between them. The transitions are designed to be pluggable, and can
 accept any object that is an instance of a `core-transition-pages`. Transitions to run
 are specified in the `transitions` attribute as a space-delimited string of `id`s of
-transition elements. Several transitions are available with `core-animated-pages` by
-default, including `hero-transition`, `cross-fade`, and `tile-cascade`.
+transition elements. A couple transitions are available with `core-animated-pages` by
+default, including `hero-transition` and `cross-fade`.
 
 Example:
 


### PR DESCRIPTION
I didn't see tile-cascade in the list of imports so I think it's actually not included by default?
